### PR TITLE
Fixed issue with inheriting ml::Text

### DIFF
--- a/include/Malena/Graphics/Shape.h
+++ b/include/Malena/Graphics/Shape.h
@@ -15,9 +15,18 @@ namespace ml
 	{
 	public:
 		using T::T;
-		Shape()
+		static T isItText() {
+			if constexpr (std::is_same_v<T, sf::Text>) {
+				return sf::Text(FontManager::getDefault());
+			} else {
+				return T();
+			}
+		}
+
+		Shape() : T(isItText())
 		{
 		}
+
 		template <typename U>
 		explicit Shape(const U &obj) : T(obj)
 		{


### PR DESCRIPTION
ml::Shape now checks if template is Text first and creates the Text first